### PR TITLE
Adding rule to snakefile for counting total and unique read pairs

### DIFF
--- a/data/Snakefile
+++ b/data/Snakefile
@@ -61,9 +61,7 @@ rule all:
         expand(
             path.join(PEAK_DIR, "{sample}_peaks.filtered.narrowPeak"),
             sample=SAMPLES)
-    
-    
-    
+
 rule qc_check:
     input:
         # FRiP calculations
@@ -76,8 +74,14 @@ rule qc_check:
         path.join(PEAK_DIR, "promoter.gencode.v"+str(config["vGENCODE"])+".peaks.bed"),
         ## non promoter peaks
         expand(
-        path.join(PEAK_DIR, "{sample}_non_promoter.gencode.v"+str(config["vGENCODE"])+".peaks.bed"),
-        sample=SAMPLES)
+            path.join(PEAK_DIR, "{sample}_non_promoter.gencode.v"+str(config["vGENCODE"])+".peaks.bed"),
+            sample=SAMPLES
+        ),
+        ## total and unique read pairs per sample
+        expand(
+            path.join(REPORT_DIR, "{sample}.duplication_report.txt"),
+            sample=SAMPLES
+        ),
     
 
 rule R_analysis:
@@ -345,7 +349,24 @@ rule keep_quality_alignments:
     threads: 3
     shell:
         "{SIF_EXEC} sambamba view -t {threads} -F {params.filter} {params.other} -o {output} {input}"
-        
+
+rule count_dups:
+    input:
+        raw = path.join(ALIGN_DIR, "{sample}.filtered.bam"),
+        dedup = path.join(ALIGN_DIR, "{sample}.filtered.dedup.sorted.bam"),
+    output:
+        path.join(REPORT_DIR, "{sample}.duplication_report.txt"),
+    run:
+        commands = [
+            "Ntot=$({SIF_EXEC} sambamba flagstat {input.raw} 2>/dev/null | head -n 1 | cut -f 1 -d ' ')",
+            "Ndedup=$({SIF_EXEC} sambamba flagstat {input.dedup} 2>/dev/null | head -n 1 | cut -f 1 -d ' ')",
+            "Fdedup=$(echo \"scale=2; 100 * $Ndedup / $Ntot\" | bc)",
+            "echo \"$Ntot total filtered read pairs, $Ndedup of which are unique ($Fdedup%)\" > {output}",
+        ]
+        command_str = "; ".join(commands)
+        shell(command_str)
+
+
 rule gunzip:
     input:
         "gencode.v"+str(config["vGENCODE"])+".annotation.gff3.gz",


### PR DESCRIPTION
This is performed after filtering for quality alignments, and produces a file in the `REPORT_DIR` folder for each sample